### PR TITLE
Use curl for artifact downloads and add error handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,7 @@ while [[ $status == *"HTTP/1.1 203"*   ]]; do
         tail -n +14 response 
         curl --retry 3 --retry-delay 5 -u "$1:$2" -s -o 'artifact.zip' $artifact
         if [[ $? -ne 0 ]]; then
+            echo "Failed to download artifact from $artifact"
             exit 202
         fi
         

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ while [[ $status == *"HTTP/1.1 203"*   ]]; do
     # We got an artifact that we can extract
     if [[ "$status" = *"HTTP/1.1 202"* ]]; then
         tail -n +14 response 
-        wget --user=$1 --password=$2 -q -O 'artifact.zip' $artifact
+        curl --retry 3 --retry-delay 5 -u "$1:$2" -s -o 'artifact.zip' $artifact
         if [[ $? -ne 0 ]]; then
             exit 202
         fi


### PR DESCRIPTION
Switch from wget to curl for downloading artifacts, ensuring compatibility with Windows environments. Include an error message for failed downloads to improve user feedback.